### PR TITLE
Added load_vendors function into MacLookup

### DIFF
--- a/mac_vendor_lookup.py
+++ b/mac_vendor_lookup.py
@@ -83,6 +83,9 @@ class MacLookup(BaseMacLookup):
     def lookup(self, mac):
         return self.loop.run_until_complete(self.async_lookup.lookup(mac))
 
+    def load_vendors(self):
+        return self.loop.run_until_complete(self.async_lookup.load_vendors())
+
 
 def main():
     import sys


### PR DESCRIPTION
Hey @bauerj ! How are you doing?

Super nice lib!

I was trying to use it and when I tried to pre-load the vendors list, i realised that the function was missing in the main class.

What do you think about the PR?