### PR TITLE
Additional Regex for MAC Addr formats aabb.ccdd.eeff

### DIFF
--- a/mac_vendor_lookup.py
+++ b/mac_vendor_lookup.py
@@ -19,7 +19,7 @@ class BaseMacLookup(object):
 
     @staticmethod
     def sanitise(_mac):
-        mac = _mac.replace(":", "").replace("-", "").upper()
+        mac = _mac.replace(":", "").replace("-", "").replace(".","").upper()
         try:
             int(mac, 16)
         except ValueError:


### PR DESCRIPTION
Add additional regex inside sanitise() to account for networking mac address formatting. e.g: aabb.ccdd.eeff