### PR TITLE
Handle exception for unrecognized vendor mac

### DIFF
--- a/mac_vendor_lookup.py
+++ b/mac_vendor_lookup.py
@@ -91,7 +91,11 @@ class AsyncMacLookup(BaseMacLookup):
             await self.load_vendors()
         if type(mac) == str:
             mac = mac.encode("utf8")
-        return self.prefixes[mac[:6]].decode("utf8")
+
+        if mac[:6] in self.prefixes.keys():
+            return self.prefixes[mac[:6]].decode("utf8")
+        else:
+            return 'Unrecognized Vendor'
 
 
 class MacLookup(BaseMacLookup):


### PR DESCRIPTION
- If user using mac which not on the list. It will have the following exceptions:
```
Traceback (most recent call last):
  File "test.py", line 3, in <module>
    print(MacLookup().lookup("02:F6:1E:F0:60:69"))
  File "/....../mac_vendor_lookup/mac_vendor_lookup.py", line 110, in lookup
    return self.loop.run_until_complete(self.async_lookup.lookup(mac))
  File "/usr/lib/python3.6/asyncio/base_events.py", line 484, in run_until_complete
    return future.result()
  File "/....../mac_vendor_lookup/mac_vendor_lookup.py", line 94, in lookup
    return self.prefixes[mac[:6]].decode("utf8")
KeyError: b'02F61E'
```
This Patch will show "Unrecognized Vendor" if input mac not on the list.