### PR TITLE
fixed bug when set a local cache_path in BaseMacLookup

### DIFF
--- a/mac_vendor_lookup.py
+++ b/mac_vendor_lookup.py
@@ -84,8 +84,9 @@ class AsyncMacLookup(BaseMacLookup):
                 # Loading the entire file into memory, then splitting is
                 # actually faster than streaming each line. (> 1000x)
                 for l in (await f.read()).splitlines():
-                    prefix, vendor = l.split(b":", 1)
-                    self.prefixes[prefix] = vendor
+                    if b"(base 16)" in l:
+                        prefix, vendor = (i.strip() for i in l.split(b"(base 16)", 1))
+                        self.prefixes[prefix] = vendor
         else:
             try:
                 os.makedirs("/".join(AsyncMacLookup.cache_path.split("/")[:-1]))


### PR DESCRIPTION
when we load a custom cache_path file from my machine i got errors. for this example bellow,  the app crash:

``` py
from mac_vendor_lookup import MacLookup, BaseMacLookup

BaseMacLookup.cache_path = "/home/storage/mac-vendors.txt"
mac = MacLookup()
    
def find_mac(mac_address):
    print(mac.lookup(mac_address))
```

my patch solve this problem. thanks 