### PR TITLE
Dowload OUI list from new httpS source

### DIFF
--- a/mac_vendor_lookup.py
+++ b/mac_vendor_lookup.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import aiofiles
 import aiohttp
 
-OUI_URL = "http://standards-oui.ieee.org/oui.txt"
+OUI_URL = "https://standards-oui.ieee.org/oui.txt"
 
 
 class InvalidMacError(Exception):
@@ -142,3 +142,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
IEE moved from HTTP to httpS as it seems, this script silently fails now.

$ curl -v -o /tmp/mac http://standards-oui.ieee.org/oui.txt Host standards-oui.ieee.org:80 was resolved.
* IPv6: (none)
* IPv4: 140.98.223.27
*   Trying 140.98.223.27:80...
* Connected to standards-oui.ieee.org (140.98.223.27) port 80
> GET /oui.txt HTTP/1.1
> Host: standards-oui.ieee.org
> User-Agent: curl/8.5.0
[...]
< HTTP/1.0 302 Moved Temporarily
< Location: https://standards-oui.ieee.org/oui.txt [...]